### PR TITLE
Expand single pull request description as major change #5

### DIFF
--- a/src/main/groovy/wooga/gradle/releaseNotesGenerator/utils/ReleaseNoteBody.groovy
+++ b/src/main/groovy/wooga/gradle/releaseNotesGenerator/utils/ReleaseNoteBody.groovy
@@ -134,7 +134,7 @@ class ReleaseNoteBody {
         new Callable<List<PullRequest>>() {
             @Override
             List<PullRequest> call() throws Exception {
-                return pullrequests.findAll { it.labels.every { it.name != LABEL_MAJOR_CHANGE } }
+                return pullrequests.size() == 1 ? new ArrayList<PullRequest>() : pullrequests.findAll { it.labels.every { it.name != LABEL_MAJOR_CHANGE } }
             }
         }
     }
@@ -143,7 +143,7 @@ class ReleaseNoteBody {
         new Callable<List<PullRequest>>() {
             @Override
             List<PullRequest> call() throws Exception {
-                return pullrequests.findAll { it.labels.any { it.name == LABEL_MAJOR_CHANGE } }
+                return pullrequests.size() == 1 ? [pullrequests.first()] : pullrequests.findAll { it.labels.any { it.name == LABEL_MAJOR_CHANGE } }
             }
         }
     }

--- a/src/test/groovy/wooga/gradle/releaseNotesGenerator/utils/ReleaseNotesGeneratorTest.groovy
+++ b/src/test/groovy/wooga/gradle/releaseNotesGenerator/utils/ReleaseNotesGeneratorTest.groovy
@@ -899,10 +899,24 @@ class ReleaseNotesGeneratorTest extends Specification {
         
         # [$versionB.version - $dateB](https://github.com/wooga/TestRepo/releases/tag/v$versionB.version) #
         
-        ## Changes ##
+        ## Major Changes ##
+
+        ### Pullrequest 1 ###
         
-        * [`#1`](https://github.com/wooga/TestRepo/pull/1) Pullrequest 1
+        #### Description
+        Yada Yada Yada Yada Yada
+        Yada Yada Yada Yada Yada
+        Yada Yada Yada Yada Yada
         
+        #### Changes
+        * ![ADD] some stuff
+        * ![REMOVE] some stuff
+        * ![FIX] some stuff
+        
+        Yada Yada Yada Yada Yada
+        Yada Yada Yada Yada Yada
+        Yada Yada Yada Yada Yada
+
         ## Dependencies ##
         
         ```bash
@@ -936,5 +950,76 @@ class ReleaseNotesGeneratorTest extends Specification {
         dateA = releaseDateA.format("dd MMMM yyyy")
         dateB = releaseDateB.format("dd MMMM yyyy")
         versions = [versionA, versionB]
+    }
+
+
+    def "creates full first release notes with a single pull request"() {
+        given: "a git log with a single pull request, commits and a tag"
+
+        git.commit(message: 'commit')
+        git.commit(message: 'commit (#1)')
+        git.tag.add(name: 'v1.0.0')
+
+        and: "mocked pull requests"
+        hub.getPullRequest(1) >> mockPullRequest(1)
+
+        and: "mocked releases"
+        mockRelease("1.0.0", releaseDateA)
+
+        when:
+        def notes = releaseNoteGenerator.generateReleaseNotes(versions, ReleaseNotesGenerator.Template.releaseNotes)
+
+        then:
+        notes.normalize() == ("""
+        # [$versionA.version - $dateA](https://github.com/wooga/TestRepo/releases/tag/v$versionA.version) #
+        
+        ## Major Changes ##
+
+        ### Pullrequest 1 ###
+        
+        #### Description
+        Yada Yada Yada Yada Yada
+        Yada Yada Yada Yada Yada
+        Yada Yada Yada Yada Yada
+        
+        #### Changes
+        * ![ADD] some stuff
+        * ![REMOVE] some stuff
+        * ![FIX] some stuff
+        
+        Yada Yada Yada Yada Yada
+        Yada Yada Yada Yada Yada
+        Yada Yada Yada Yada Yada
+
+        ## Dependencies ##
+        
+        ```bash
+        Wooga.TestDependency1 ~> 0.1.0
+        Wooga.TestDependency2 = 0.7
+        Wooga.TestDependency3 
+        Wooga.TestDependency4 master
+        Wooga.TestDependency4 > 1, <2
+        ```
+
+        ## How to install ##
+        
+        ```bash
+        # latest stable
+        nuget Wooga.Test ~> 1
+        # latest stable with only patch updates
+        nuget Wooga.Test ~> 1.0
+        # latest build from master
+        nuget Wooga.Test ~> 1 master
+        # latest build with release candidates
+        nuget Wooga.Test ~> 1 rc
+        ```
+        """.stripIndent() + TestContent.ICON_IDS).trim()
+
+        where:
+        versionA = new ReleaseVersion("1.0.0", null, false)
+        releaseDateA = new Date(2012, 8, 12)
+
+        dateA = releaseDateA.format("dd MMMM yyyy")
+        versions = [versionA]
     }
 }


### PR DESCRIPTION
## Description
We have the possibility to mark specific changes as Major changes in the pull request to fill the release notes with the description body of the pull request.

We expand now single pullrequests as `Major Change`

resolves #5 

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
