### PR TITLE
Use new buildGradlePlugin step instead of custom script


### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,102 +1,23 @@
 #!groovy
-@Library('github.com/wooga/atlas-jenkins-pipeline@0.0.3') _
+@Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
-pipeline {
-    agent none
+withCredentials([usernamePassword(credentialsId: 'github_integration', passwordVariable: 'githubPassword', usernameVariable: 'githubUser'),
+                 usernamePassword(credentialsId: 'github_integration_2', passwordVariable: 'githubPassword2', usernameVariable: 'githubUser2'),
+                 string(credentialsId: 'atlas_releaseNotesGenerator_coveralls_token', variable: 'coveralls_token')]) {
 
-    stages {
-        stage('Preparation') {
-            agent any
+    def testEnvironment = [ 'osx':
+                               [
+                                   "ATLAS_GITHUB_INTEGRATION_USER=${githubUser}",
+                                   "ATLAS_GITHUB_INTEGRATION_PASSWORD=${githubPassword}",
+                                   "UNITY_PATH=${env.UNITY_2017_1_0_P_5_PATH}"
+                               ],
+                             'windows':
+                               [
+                                   "ATLAS_GITHUB_INTEGRATION_USER=${githubUser2}",
+                                   "ATLAS_GITHUB_INTEGRATION_PASSWORD=${githubPassword2}",
+                                   "UNITY_PATH=${env.UNITY_2017_1_0_P_5_PATH}"
+                               ]
+                        ]
 
-            steps {
-                sendSlackNotification "STARTED", true
-            }
-        }
-
-        stage('check') {
-            parallel {
-                stage('Windows') {
-                    agent {
-                        label 'windows&&atlas'
-                    }
-
-                    environment {
-                        COVERALLS_REPO_TOKEN    			= credentials('atlas_releaseNotesGenerator_coveralls_token')
-                        TRAVIS_JOB_NUMBER       			= "${BUILD_NUMBER}.WIN"
-                        UNITY_PATH              			= "${UNITY_2017_1_0_P_5_PATH}"
-						GITHUB                            	= credentials('github_integration')
-                        ATLAS_GITHUB_INTEGRATION_USER     	= "${GITHUB_USR}"
-                        ATLAS_GITHUB_INTEGRATION_PASSWORD 	= "${GITHUB_PSW}"
-                    }
-
-                    steps {
-                        gradleWrapper "check"
-                    }
-
-                    post {
-                        success {
-                            gradleWrapper "jacocoTestReport coveralls"
-			    publishHTML([
-                                allowMissing: true,
-                                alwaysLinkToLastBuild: true,
-                                keepAll: true,
-                                reportDir: 'build/reports/jacoco/test/html',
-                                reportFiles: 'index.html',
-                                reportName: 'Coverage',
-                                reportTitles: ''
-                            ])	
-                        }
-
-                        always {
-                            junit allowEmptyResults: true, testResults: 'build/test-results/**/*.xml'
-                        }
-                    }
-                }
-
-                stage('macOS') {
-                    agent {
-                        label 'osx&&atlas&&secondary'
-                    }
-
-                    environment {
-                        COVERALLS_REPO_TOKEN    			= credentials('atlas_releaseNotesGenerator_coveralls_token')
-                        TRAVIS_JOB_NUMBER       			= "${BUILD_NUMBER}.MACOS"
-                        UNITY_PATH              			= "${UNITY_2017_1_0_P_5_PATH}"
-						GITHUB                            	= credentials('github_integration')
-                        ATLAS_GITHUB_INTEGRATION_USER     	= "${GITHUB_USR}"
-						ATLAS_GITHUB_INTEGRATION_PASSWORD 	= "${GITHUB_PSW}"
-                    }
-
-                    steps {
-                        gradleWrapper "check"
-                    }
-
-                    post {
-                        success {
-                            gradleWrapper "jacocoTestReport coveralls"
-			    publishHTML([
-                                allowMissing: true,
-                                alwaysLinkToLastBuild: true,
-                                keepAll: true,
-                                reportDir: 'build/reports/jacoco/test/html',
-                                reportFiles: 'index.html',
-                                reportName: 'Coverage',
-                                reportTitles: ''
-                            ])	
-                        }
-
-                        always {
-                            junit allowEmptyResults: true, testResults: 'build/test-results/**/*.xml'
-                        }
-                    }
-                }
-            }
-
-            post {
-                always {
-                    sendSlackNotification currentBuild.result, true
-                }
-            }
-        }
-    }
+    buildGradlePlugin plaforms: ['osx','windows'], coverallsToken: coveralls_token, testEnvironment: testEnvironment
 }


### PR DESCRIPTION
## Description

To unify the atlas plugin build steps I added a new custom step to https://github.com/wooga/atlas-jenkins-pipeline

This steps tests and publishes gradle plugins. At the moment, the custom test configuration has to be set from the outside.

```groovy
def coveralls_token = "coveralls token" //can be null

def testEnvironment = [
                        "test_var_1=value1",
                        "test_var_2=value2"
                       ]

buildGradlePlugin plaforms: ['osx'], coverallsToken: coveralls_token, testEnvironment: testEnvironment
```

see wooga/rfcs#4

## Changes

![IMPROVE] Jenkinsfile by using custom build step

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
