### PR TITLE
Makes parsing of change list more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ Tested with Oracle JDK8
 
 Development
 ===========
+
+#### Running the tests
+The integration tests will access github with a botUser which credentials needs to be provided via environment variables.
+
+| Name                                | Description                                                                          |
+| ----------------------------------- | ------------------------------------------------------------------------------------ |
+| `ATLAS_GITHUB_INTEGRATION_USER`     | The username for of the BotUser. The name will also be used for the test repository. |
+| `ATLAS_GITHUB_INTEGRATION_PASSWORD` | A password for the gihub user or acces token.                                        |
+
+If the value of `ATLAS_GITHUB_INTEGRATION_PASSWORD` is a access token, it needs the scopes: `delete_repo`, `repo`
+see [github-oauth-scopes] for more information.
+
 [Code of Conduct](docs/Code-of-conduct.md)
 
 LICENSE

--- a/src/integrationTest/groovy/wooga/gradle/releaseNotesGenerator/GithubIntegration.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/releaseNotesGenerator/GithubIntegration.groovy
@@ -17,7 +17,6 @@
 
 package wooga.gradle.releaseNotesGenerator
 
-import nebula.test.IntegrationSpec
 import org.kohsuke.github.GHRelease
 import org.kohsuke.github.GHRepository
 import org.kohsuke.github.GitHub

--- a/src/integrationTest/groovy/wooga/gradle/releaseNotesGenerator/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/releaseNotesGenerator/IntegrationSpec.groovy
@@ -17,7 +17,13 @@
 
 package wooga.gradle.releaseNotesGenerator
 
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.ProvideSystemProperty
+
 class IntegrationSpec extends nebula.test.IntegrationSpec {
+
+    @Rule
+    ProvideSystemProperty properties = new ProvideSystemProperty("ignoreDeprecations", "true")
 
     def setup() {
         def gradleVersion = System.getenv("GRADLE_VERSION")

--- a/src/main/groovy/wooga/gradle/releaseNotesGenerator/utils/ReleaseNoteBody.groovy
+++ b/src/main/groovy/wooga/gradle/releaseNotesGenerator/utils/ReleaseNoteBody.groovy
@@ -79,11 +79,13 @@ class ReleaseNoteBody {
 
             def changes = body.readLines().findAll { it.trim().startsWith("* ![") }
             changeList = changes.collect {
-                def match = (it =~ /\!\[(.*?)\] (.*)/)
-                String category = match[0][1].toString()
-                String text = match[0][2].toString()
-                new ChangeNote(category, text)
-            }
+                def match = (it =~ /\!\[(.*?)\] (.+)/)
+                if (match) {
+                    String category = match[0][1].toString()
+                    String text = match[0][2].toString()
+                    new ChangeNote(category, text)
+                }
+            } - null
         }
     }
 


### PR DESCRIPTION
## Description
Parsing of change list is a bit picky and currently throws for some malformed change lists. This does not improve the parsing but prevents throwing the parse exception. Changes are dropped.

## Changes
* ![FIX] don't throw on change list parse errors

resolves [#11](https://github.com/wooga/atlas-releaseNotesGenerator/issues/11)

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
